### PR TITLE
Update auto-prioritization to use new labels #2053

### DIFF
--- a/mungegithub/mungers/flake-manager.go
+++ b/mungegithub/mungers/flake-manager.go
@@ -313,14 +313,14 @@ func (p *individualFlakeSource) AddTo(previous string) string {
 
 // Labels implements IssueSource
 func (p *individualFlakeSource) Labels() []string {
-	return []string{"kind/flake", sync.PriorityP2.String()}
+	return []string{"kind/flake", sync.PriorityImportantLongterm.String()}
 }
 
 // Priority implements IssueSource
 func (p *individualFlakeSource) Priority(obj *github.MungeObject) (sync.Priority, bool) {
 	comments, ok := obj.ListComments()
 	if !ok {
-		return sync.PriorityP2, false
+		return sync.PriorityImportantLongterm, false
 	}
 	// Different IssueSource's Priority calculation may differ
 	return autoPrioritize(comments, obj.Issue.CreatedAt), true
@@ -391,14 +391,14 @@ func (p *brokenJobSource) AddTo(previous string) string {
 
 // Labels implements IssueSource
 func (p *brokenJobSource) Labels() []string {
-	return []string{"kind/flake", "team/test-infra", sync.PriorityP2.String()}
+	return []string{"kind/flake", "team/test-infra", sync.PriorityImportantLongterm.String()}
 }
 
 // Priority implements IssueSource
 func (p *brokenJobSource) Priority(obj *github.MungeObject) (sync.Priority, bool) {
 	comments, ok := obj.ListComments()
 	if !ok {
-		return sync.PriorityP2, false
+		return sync.PriorityImportantLongterm, false
 	}
 	// Different IssueSource's Priority calculation may differ
 	return autoPrioritize(comments, obj.Issue.CreatedAt), true
@@ -437,13 +437,13 @@ func autoPrioritize(comments []*libgithub.IssueComment, issueCreatedAt *time.Tim
 	// P1: 10 - 50 times in a week
 	// P2: 3 or more times in a week
 	// p3: happens once or twice in a week (default value)
-	p := sync.PriorityP3
+	p := sync.PriorityBacklog
 	if weekCount >= 50 {
-		p = sync.PriorityP0
+		p = sync.PriorityCriticalUrgent
 	} else if weekCount >= 10 {
-		p = sync.PriorityP1
+		p = sync.PriorityImportantSoon
 	} else if weekCount >= 3 {
-		p = sync.PriorityP2
+		p = sync.PriorityImportantLongterm
 	}
 	return p
 }

--- a/mungegithub/mungers/sync/issue-sync.go
+++ b/mungegithub/mungers/sync/issue-sync.go
@@ -31,15 +31,17 @@ const (
 	BotName = "k8s-merge-robot"
 	// JenkinsBotName is the name of kubekins bot
 	JenkinsBotName = "k8s-bot"
-	priorityPrefix = "priority/P"
-	// PriorityP0 represents Priority P0
-	PriorityP0 = Priority(0)
-	// PriorityP1 represents Priority P1
-	PriorityP1 = Priority(1)
-	// PriorityP2 represents Priority P2
-	PriorityP2 = Priority(2)
-	// PriorityP3 represents Priority P3
-	PriorityP3 = Priority(3)
+
+	priorityPrefix = "priority/"
+
+	// PriorityCriticalUrgent represents Prority/critcal-urgent
+	PriorityCriticalUrgent = Priority(0)
+	// PriorityImportantSoon represents Priority/important-soon
+	PriorityImportantSoon = Priority(1)
+	// PriorityImportantLongterm represents Priority/important-longterm
+	PriorityImportantLongterm = Priority(2)
+	// PriorityBacklog represents Priority/backlog
+	PriorityBacklog = Priority(3)
 )
 
 // RobotUser is a set of name of robot user
@@ -50,7 +52,16 @@ type Priority int
 
 // String return the priority label in string
 func (p Priority) String() string {
-	return fmt.Sprintf(priorityPrefix+"%d", p)
+	switch p {
+    case PriorityCriticalUrgent:
+        return priorityPrefix + "critical-urgent"
+    case PriorityImportantSoon:
+        return priorityPrefix + "important-soon"
+    case PriorityImportantLongterm:
+        return priorityPrefix + "important-longterm"
+    default:
+    	return priorityPrefix + "backlog"
+    }
 }
 
 // Priority returns the priority in int


### PR DESCRIPTION
Updated the string mappings for priorities P0-P3. Updated references to PriorityP0/1/2/3 in flake-manager.go.